### PR TITLE
Preserve JS Object types in state persistance

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "run-server": "webpack-dev-server"
   },
   "dependencies": {
+    "lodash-es": "^4.17.15",
     "vue": "^3.0.0-alpha.1"
   },
   "devDependencies": {

--- a/src/store/main.ts
+++ b/src/store/main.ts
@@ -1,5 +1,6 @@
 import {reactive, readonly, watch, ref, Ref} from 'vue';
 import {set, get} from 'idb-keyval'
+import { cloneDeep } from 'lodash-es'
 
 
 export abstract class Store<T extends Object> {
@@ -30,9 +31,9 @@ export abstract class PersistentStore<T extends Object> extends Store<T> {
         if(this.isInitialized) {
             let stateFromIndexedDB: string = await get(this.storeName);
             if(stateFromIndexedDB) {
-                Object.assign(this.state, JSON.parse(stateFromIndexedDB))
+                Object.assign(this.state, stateFromIndexedDB)
             }
-            watch(() => this.state, (val) => set(this.storeName, JSON.stringify(val)), {deep: true})
+            watch(() => this.state, (val) => set(this.storeName, cloneDeep(val)), {deep: true})
 
             this.isInitialized.value = true;
         }


### PR DESCRIPTION
Fantastic example repo and thanks for the write up, Instead of fighting json when hydrating the state form the store with JS types, I found since this example sticks to indexedDB that supports JS object directly, you only need to tangle with JSON if you want to use another store for compatibility like webSQL or localstorage.

It would be nice to not pull in lodash but that's a better solution that anything I tried. 

>     IndexedDB uses the structured clone algorithm[1] which understands
>     JS object types like `Date` or `Set` that is lost casting the state
>     back and forth to JSON strings.
> 
>     Reactivity is removed from the object being stored which
>     is why cloneDeep is included as indexedDB requires plain objects.
>     Removing the Proxy[2] on this.state with lodash cloneDeep



1: [indexedDB structured clone algorithm](https://developer.mozilla.org/en-US/docs/Web/API/Web_Workers_API/Structured_clone_algorithm)

2: [Proxy](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Proxy)
